### PR TITLE
Pin openshift-client version to 1.0.21 as the new major version break…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.18.4
-openshift-client>=1.0
+openshift-client==1.0.21


### PR DESCRIPTION
…s things.

I will soon stop using this openshift client altogether in favor of the dynamic openshift client so it's not worth trying to figure out what broke things in the newer version.