### PR TITLE
We no longer need the openshift client because

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,13 @@ This was a fork of https://github.com/OCP-on-NERC/xdmod-openshift-scripts
 
 ## Usage
 
-In order to run the scripts, you need to run `oc login` or set the following environment variables:
+In order to run the scripts, you need to set the following environment variables:
 
-- `OPENSHIFT_TOKEN` for both scripts.
-- `OPENSHIFT_API_URL=https://api.shift.nerc.mghpcc.org:6443` for `merge.py`.
+- `OPENSHIFT_TOKEN` for `openshift_prometheus_metrics.py` when collecting metrics from thanos/prometheus.
+- Keycloak `CLIENT_ID` and `CLIENT_SECRET`, `COLDFRONT_URL` (defaults to MGHPCC coldfront) for `merge.py`.
 
 We are using the token for `xdmod-reader` service account in `xdmod-reader` namespace on nerc-prod cluster. You can extract the token with:
 `oc get secrets -n xdmod-reader --as system:admin xdmod-reader-token-m6s2m -o yaml | yq .data.token -r |base64 -d` .
-
-Note that if you are logged in with `oc login` then you don't need to manually set the OPENSHIFT_TOKEN or OPENSHIFT_API_URL.
 
 When running the scripts, there are two methods of specifying the OpenShift Prometheus
 endpoint. The first is through an environment variable:

--- a/openshift_metrics/openshift_prometheus_metrics.py
+++ b/openshift_metrics/openshift_prometheus_metrics.py
@@ -19,8 +19,6 @@ import os
 import sys
 import json
 
-import openshift
-
 import utils
 
 
@@ -72,9 +70,6 @@ def main():
 
 
     token = os.environ.get("OPENSHIFT_TOKEN")
-
-    if token is None:
-        token = openshift.get_auth_token()
 
     metrics_dict = {}
     metrics_dict["start_date"] = report_start_date

--- a/openshift_metrics/tests/test_utils.py
+++ b/openshift_metrics/tests/test_utils.py
@@ -15,7 +15,6 @@ import tempfile
 from unittest import TestCase, mock
 
 from openshift_metrics import utils
-import openshift as oc
 import os
 
 class TestQueryMetric(TestCase):

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -20,8 +20,6 @@ import math
 import csv
 import requests
 
-import openshift
-
 
 # GPU types
 GPU_A100 = "nvidia.com/gpu_A100"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests>=2.18.4
-openshift-client==1.0.21


### PR DESCRIPTION
1. For gathering metrics we make a request call and for that we can set the openshift token as an environment variable.
2. We no longer gather namespace annotations, instead we are getting allocation attributes from coldfront.