### PR TITLE
Handle network failures when gathering metrics.

### DIFF
--- a/openshift_metrics/tests/test_utils.py
+++ b/openshift_metrics/tests/test_utils.py
@@ -10,7 +10,7 @@
 #   License for the specific language governing permissions and limitations
 #   under the License.
 #
-
+from requests.exceptions import ConnectionError
 import tempfile
 from unittest import TestCase, mock
 
@@ -40,6 +40,28 @@ class TestQueryMetric(TestCase):
         self.assertRaises(Exception, utils.query_metric, 'fake-url', 'fake-token',
                           'fake-metric', '2022-03-14', '2022-03-14')
         self.assertEqual(mock_get.call_count, 3)
+
+    @mock.patch('requests.get')
+    @mock.patch('time.sleep')
+    def test_query_metric_connection_error(self, mock_sleep, mock_get):
+        mock_get.side_effect = [ConnectionError] * 3
+        self.assertRaises(ConnectionError, utils.query_metric, 'fake-url', 'fake-token',
+                  'fake-metric', '2022-03-14', '2022-03-14')
+        self.assertEqual(mock_get.call_count, 3)
+
+    @mock.patch('requests.get')
+    @mock.patch('time.sleep')
+    def test_query_metric_connection_error_success(self, mock_sleep, mock_get):
+        mock_response = mock.Mock(status_code=200)
+        mock_response.json.return_value = {"data": {
+            "result": "this is data"
+        }}
+        mock_get.return_value = mock_response
+
+        # Raise ConnectionError once and then succeed
+        mock_get.side_effect = [ConnectionError] + [mock.DEFAULT]
+        utils.query_metric('fake-url', 'fake-token', 'fake-metric', '2022-03-14', '2022-03-14')
+        self.assertEqual(mock_get.call_count, 2)
 
 class TestGetNamespaceAnnotations(TestCase):
 

--- a/openshift_metrics/tests/test_utils.py
+++ b/openshift_metrics/tests/test_utils.py
@@ -19,7 +19,7 @@ import os
 
 class TestQueryMetric(TestCase):
 
-    @mock.patch('requests.get')
+    @mock.patch('requests.Session.get')
     @mock.patch('time.sleep')
     def test_query_metric(self, mock_sleep, mock_get):
         mock_response = mock.Mock(status_code=200)
@@ -28,40 +28,27 @@ class TestQueryMetric(TestCase):
         }}
         mock_get.return_value = mock_response
 
-        metrics = utils.query_metric('fake-url', 'fake-token', 'fake-metric', '2022-03-14', '2022-03-14')
+        metrics = utils.query_metric('https://fake-url', 'fake-token', 'fake-metric', '2022-03-14', '2022-03-14')
         self.assertEqual(metrics, "this is data")
         self.assertEqual(mock_get.call_count, 1)
 
-    @mock.patch('requests.get')
+    @mock.patch('requests.Session.get')
     @mock.patch('time.sleep')
     def test_query_metric_exception(self, mock_sleep, mock_get):
         mock_get.return_value = mock.Mock(status_code=404)
 
-        self.assertRaises(Exception, utils.query_metric, 'fake-url', 'fake-token',
+        self.assertRaises(Exception, utils.query_metric, 'https://fake-url', 'fake-token',
                           'fake-metric', '2022-03-14', '2022-03-14')
         self.assertEqual(mock_get.call_count, 3)
 
-    @mock.patch('requests.get')
+    @mock.patch('requests.Session.get')
     @mock.patch('time.sleep')
     def test_query_metric_connection_error(self, mock_sleep, mock_get):
-        mock_get.side_effect = [ConnectionError] * 3
-        self.assertRaises(ConnectionError, utils.query_metric, 'fake-url', 'fake-token',
+        mock_get.side_effect = [ConnectionError]
+        self.assertRaises(ConnectionError, utils.query_metric, 'https://fake-url', 'fake-token',
                   'fake-metric', '2022-03-14', '2022-03-14')
-        self.assertEqual(mock_get.call_count, 3)
+        self.assertEqual(mock_get.call_count, 1)
 
-    @mock.patch('requests.get')
-    @mock.patch('time.sleep')
-    def test_query_metric_connection_error_success(self, mock_sleep, mock_get):
-        mock_response = mock.Mock(status_code=200)
-        mock_response.json.return_value = {"data": {
-            "result": "this is data"
-        }}
-        mock_get.return_value = mock_response
-
-        # Raise ConnectionError once and then succeed
-        mock_get.side_effect = [ConnectionError] + [mock.DEFAULT]
-        utils.query_metric('fake-url', 'fake-token', 'fake-metric', '2022-03-14', '2022-03-14')
-        self.assertEqual(mock_get.call_count, 2)
 
 class TestGetNamespaceAnnotations(TestCase):
 

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -21,6 +21,8 @@ import csv
 import requests
 import boto3
 
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 
 # GPU types
 GPU_A100 = "nvidia.com/gpu_A100"
@@ -101,32 +103,27 @@ def upload_to_s3(file, bucket, location):
 
 def query_metric(openshift_url, token, metric, report_start_date, report_end_date):
     """Queries metric from prometheus/thanos for the provided openshift_url"""
-    retries = 3
-    connection_errors = 0
-
     data = None
     headers = {"Authorization": f"Bearer {token}"}
     day_url_vars = f"start={report_start_date}T00:00:00Z&end={report_end_date}T23:59:59Z"
-    print(f"Retrieving metric: {metric}")
     url = f"{openshift_url}/api/v1/query_range?query={metric}&{day_url_vars}&step={STEP_MIN}m"
 
-    for _ in range(retries):
-        try:
-            response = requests.get(url, headers=headers, verify=True)
+    retries = Retry(total=3, backoff_factor=1, status_forcelist=[429, 500, 502, 503, 504])
+    session = requests.Session()
+    session.mount("https://", HTTPAdapter(max_retries=retries))
 
-            if response.status_code != 200:
-                print(f"{response.status_code} Response: {response.reason}")
-            else:
-                data = response.json()["data"]["result"]
-                if data:
-                    break
-                print("Empty result set")
-        except requests.exceptions.ConnectionError:
-            connection_errors += 1
-            print("Connection Error " + str(connection_errors))
-            if connection_errors == retries:
-                raise
+    print(f"Retrieving metric: {metric}")
 
+    for _ in range(3):
+        response = session.get(url, headers=headers, verify=True)
+
+        if response.status_code != 200:
+            print(f"{response.status_code} Response: {response.reason}")
+        else:
+            data = response.json()["data"]["result"]
+            if data:
+                break
+            print("Empty result set")
         time.sleep(3)
 
     if not data:


### PR DESCRIPTION
We do this by handling ConnectionError thrown by requests.

I have run into intermittent DNS failures before so we'll now retry a couple of times before giving up.