### PR TITLE
Run a cronjob that generates monthly openshift usage report.

### DIFF
--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
   - daily-openshift-metrics-collector-cronjob.yaml
+  - produce-report-cronjob.yaml
+  - metrics-downloader-configmap.yaml

--- a/k8s/base/metrics-downloader-configmap.yaml
+++ b/k8s/base/metrics-downloader-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-downloader
+data:
+  script.sh: |
+    DIRECTORY_NAME=$(date --date="$(date +%Y-%m-15) -1 month" +'data_%Y-%m')
+    echo $DIRECTORY_NAME
+    aws s3 cp s3://openshift-metrics/$DIRECTORY_NAME/ /data --endpoint-url=https://s3.us-east-005.backblazeb2.com --recursive

--- a/k8s/base/produce-report-cronjob.yaml
+++ b/k8s/base/produce-report-cronjob.yaml
@@ -1,0 +1,66 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: produce-report
+spec:
+  schedule: "0 13 1 * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: daily-openshift-metrics-collector
+            image: ghcr.io/cci-moc/openshift-usage-scripts:main
+            env:
+            - name: S3_OUTPUT_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: nerc-invoices-b2-bucket
+                  key: access-key-id
+            - name: S3_OUTPUT_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: nerc-invoices-b2-bucket
+                  key: secret-access-key
+            - name: CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-client
+                  key: client-id
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: keycloak-client
+                  key: client-secret
+            volumeMounts:
+            - name: data-volume
+              mountPath: /data
+            command: ["/bin/sh", "-c", "cd /data && python /app/openshift_metrics/merge.py /data/*.json --upload-to-s3"]
+          initContainers:
+            - name: download-metrics
+              image: amazon/aws-cli
+              command: ["/bin/sh", "-c", "/script/script.sh"]
+              env:
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: openshift-metrics-b2-bucket
+                    key: access-key-id
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: openshift-metrics-b2-bucket
+                    key: secret-access-key
+              volumeMounts:
+                - name: data-volume
+                  mountPath: /data
+                - name: metrics-downloader
+                  mountPath: /script
+          volumes:
+          - name: data-volume
+            emptyDir: {}
+          - name: metrics-downloader
+            configMap:
+              name: metrics-downloader
+              defaultMode: 0555
+          restartPolicy: OnFailure

--- a/k8s/overlay/dev/keycloak-client.yaml
+++ b/k8s/overlay/dev/keycloak-client.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keycloak-client
+type: Opaque
+data:
+  client-id: id
+  client-secret: secret

--- a/k8s/overlay/dev/kustomization.yaml
+++ b/k8s/overlay/dev/kustomization.yaml
@@ -2,4 +2,6 @@ resources:
   - ../../base
   - openshift-metrics-b2-bucket.yaml
   - metrics-reader-token.yaml
+  - nerc-invoices-b2-bucket.yaml
+  - keycloak-client.yaml
 namespace: xdmod-reader

--- a/k8s/overlay/dev/nerc-invoices-b2-bucket.yaml
+++ b/k8s/overlay/dev/nerc-invoices-b2-bucket.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nerc-invoices-b2-bucket
+type: Opaque
+data:
+  access-key-id: 1234
+  secret-access-key: secret


### PR DESCRIPTION
The k8s cronjob uses an init container that downloads the metrics from the previous month and then the main container generates the report and uploads it to our B2 bucket.