### PR TITLE
Treat gpu_type similar to the other metrics (cpu_request, gpu_request…

### DIFF
--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -70,7 +70,7 @@ def main():
         report_month += " to " + datetime.strftime(report_end_date, "%Y-%m")
 
     condensed_metrics_dict = utils.condense_metrics(
-        merged_dictionary, ["cpu_request", "memory_request", "gpu_request"]
+        merged_dictionary, ["cpu_request", "memory_request", "gpu_request", "gpu_type"]
     )
     utils.write_metrics_by_namespace(
         condensed_metrics_dict,


### PR DESCRIPTION
…, memory_request)

This is because a pod with the same name can go from not having a GPU to then having a GPU. Similarly, a pod could request a different kind of GPU. This way we can separate out instances when the pod changed gpu_types.