### PR TITLE
This adds mechanism to get gpu type based on the kubernetes node name

### DIFF
--- a/gpu_node_map.json
+++ b/gpu_node_map.json
@@ -1,0 +1,17 @@
+{
+    "wrk-88": "Tesla-V100-PCIE-32GB",
+    "wrk-89": "Tesla-V100-PCIE-32GB",
+    "wrk-94": "NVIDIA-A100-SXM4-40GB",
+    "wrk-95": "NVIDIA-A100-SXM4-40GB",
+    "wrk-97": "NVIDIA-A100-SXM4-40GB",
+    "wrk-98": "NVIDIA-A100-SXM4-40GB",
+    "wrk-99": "NVIDIA-A100-SXM4-40GB",
+    "wrk-102": "Tesla-V100-PCIE-32GB",
+    "wrk-103": "Tesla-V100-PCIE-32GB",
+    "wrk-104": "Tesla-V100-PCIE-32GB",
+    "wrk-105": "Tesla-V100-PCIE-32GB",
+    "wrk-106": "Tesla-V100-PCIE-32GB",
+    "wrk-107": "Tesla-V100-PCIE-32GB",
+    "wrk-108": "Tesla-V100-PCIE-32GB"
+}
+

--- a/openshift_metrics/metrics_processor.py
+++ b/openshift_metrics/metrics_processor.py
@@ -71,8 +71,8 @@ class MetricsProcessor:
             gpu_resource = metric["metric"].get("resource")
             node_model = metric["metric"].get("label_nvidia_com_gpu_machine")
 
-            # If GPU labels aren't found then try to determine the gpu type
-            # from the gpu node map file
+            # Sometimes GPU labels from the nodes can be missing, in that case
+            # we get the gpu_type from the gpu-node file
             if gpu_type == GPU_UNKNOWN_TYPE:
                 node_name = metric["metric"].get("node")
                 gpu_type = self.gpu_mapping.get(node_name, GPU_UNKNOWN_TYPE)

--- a/openshift_metrics/metrics_processor.py
+++ b/openshift_metrics/metrics_processor.py
@@ -1,3 +1,4 @@
+import json
 from typing import List, Dict
 from collections import namedtuple
 
@@ -8,9 +9,15 @@ GPUInfo = namedtuple("GPUInfo", ["gpu_type", "gpu_resource", "node_model"])
 class MetricsProcessor:
     """Provides methods for merging metrics and processing it for billing purposes"""
 
-    def __init__(self, interval_minutes: int = 15, merged_data: dict = None):
+    def __init__(
+        self,
+        interval_minutes: int = 15,
+        merged_data: dict = None,
+        gpu_mapping_file: str = "gpu_node_map.json",
+    ):
         self.interval_minutes = interval_minutes
         self.merged_data = merged_data if merged_data is not None else {}
+        self.gpu_mapping = self._load_gpu_mapping(gpu_mapping_file)
 
     def merge_metrics(self, metric_name, metric_list):
         """Merge metrics (cpu, memory, gpu) by pod"""
@@ -51,8 +58,7 @@ class MetricsProcessor:
                         "node"
                     ] = node
 
-    @staticmethod
-    def _extract_gpu_info(metric_name: str, metric: Dict) -> GPUInfo:
+    def _extract_gpu_info(self, metric_name: str, metric: Dict) -> GPUInfo:
         """Extract GPU related info"""
         gpu_type = None
         gpu_resource = None
@@ -65,7 +71,21 @@ class MetricsProcessor:
             gpu_resource = metric["metric"].get("resource")
             node_model = metric["metric"].get("label_nvidia_com_gpu_machine")
 
+            # If GPU labels aren't found then try to determine the gpu type
+            # from the gpu node map file
+            if gpu_type == GPU_UNKNOWN_TYPE:
+                node_name = metric["metric"].get("node")
+                gpu_type = self.gpu_mapping.get(node_name, GPU_UNKNOWN_TYPE)
+
         return GPUInfo(gpu_type, gpu_resource, node_model)
+
+    @staticmethod
+    def _load_gpu_mapping(file_path: str) -> Dict[str, str]:
+        try:
+            with open(file_path, "r") as file:
+                return json.load(file)
+        except FileNotFoundError:
+            return {}
 
     def condense_metrics(self, metrics_to_check: List[str]) -> Dict:
         """

--- a/openshift_metrics/metrics_processor.py
+++ b/openshift_metrics/metrics_processor.py
@@ -1,6 +1,10 @@
 import json
 from typing import List, Dict
 from collections import namedtuple
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 GPU_UNKNOWN_TYPE = "GPU_UNKNOWN_TYPE"
 GPUInfo = namedtuple("GPUInfo", ["gpu_type", "gpu_resource", "node_model"])
@@ -85,6 +89,7 @@ class MetricsProcessor:
             with open(file_path, "r") as file:
                 return json.load(file)
         except FileNotFoundError:
+            logger.warning("Could not load gpu-node map file: %s", file_path)
             return {}
 
     def condense_metrics(self, metrics_to_check: List[str]) -> Dict:

--- a/openshift_metrics/tests/test_metrics_processor.py
+++ b/openshift_metrics/tests/test_metrics_processor.py
@@ -647,3 +647,30 @@ class TestExtractGPUInfo(TestCase):
             # When the GPU label is present in the metrics, then the value in the gpu-node mapping isn't considered
             gpu_info = processor._extract_gpu_info("gpu_request", metric_with_label)
             assert gpu_info.gpu_type == "V100-GPU"
+
+    def test_extract_gpu_info_no_info_anywhere(self):
+        """When node is missing in the file, we get no gpu info"""
+        mocked_gpu_mapping = {
+            "node-2": "doesnt-matter",
+        }
+        metric_with_label = {
+            "metric": {
+                "pod": "pod2",
+                "namespace": "namespace1",
+                "resource": "cpu",
+                "resource": "nvidia.com/gpu",
+                "node": "node-1",
+            },
+            "values": [
+                [60, 2],
+            ],
+        }
+        with mock.patch.object(
+            metrics_processor.MetricsProcessor,
+            "_load_gpu_mapping",
+            return_value=mocked_gpu_mapping,
+        ):
+            processor = metrics_processor.MetricsProcessor()
+            gpu_info = processor._extract_gpu_info("gpu_request", metric_with_label)
+
+            assert gpu_info.gpu_type == metrics_processor.GPU_UNKNOWN_TYPE


### PR DESCRIPTION
We now read from a file to get a static mapping of nodes and the GPU model on those nodes. This is used only when the labels on the nodes are missing.