### PR TITLE
Feature/ignore hours

### DIFF
--- a/openshift_metrics/invoice.py
+++ b/openshift_metrics/invoice.py
@@ -118,16 +118,15 @@ class Pod:
         """Return runtime eligible for billing in hours"""
 
         total_runtime = self.duration
-        end_time = self.start_time + self.duration
 
         if ignore_times:
             for ignore_start_date, ignore_end_date in ignore_times:
                 ignore_start = int(ignore_start_date.timestamp())
                 ignore_end = int(ignore_end_date.timestamp())
-                if ignore_end <= self.start_time or ignore_start >= end_time:
+                if ignore_end <= self.start_time or ignore_start >= self.end_time:
                     continue
                 overlap_start = max(self.start_time, ignore_start)
-                overlap_end = min(end_time, ignore_end)
+                overlap_end = min(self.end_time, ignore_end)
 
                 overlap_duration = max(0, overlap_end - overlap_start)
                 total_runtime = max(0, total_runtime - overlap_duration)

--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -3,7 +3,7 @@ Merges metrics from files and produces reports by pod and by namespace
 """
 
 import argparse
-from datetime import datetime
+from datetime import datetime, UTC
 import json
 from typing import Tuple
 
@@ -20,9 +20,10 @@ def compare_dates(date_str1, date_str2):
 def parse_timestamp_range(timestamp_range: str) -> Tuple[datetime, datetime]:
     try:
         start_str, end_str = timestamp_range.split(",")
-        start_dt = datetime.fromisoformat(start_str)
-        end_dt = datetime.fromisoformat(end_str)
-        if start_dt < end_dt:
+        start_dt = datetime.fromisoformat(start_str).replace(tzinfo=UTC)
+        end_dt = datetime.fromisoformat(end_str).replace(tzinfo=UTC)
+
+        if start_dt > end_dt:
             raise argparse.ArgumentTypeError("Ignore start time is after ignore end time")
         return start_dt, end_dt
     except ValueError:
@@ -43,7 +44,7 @@ def main():
         "--ignore-hours",
         type=parse_timestamp_range,
         nargs="*",
-        help="List of timestamp ranges to ignore in the format 'YYYY-MM-DDTHH:MM:SS,YYYY-MM-DDTHH:MM:SS'"
+        help="List of timestamp ranges in UTC to ignore in the format 'YYYY-MM-DDTHH:MM:SS,YYYY-MM-DDTHH:MM:SS'"
     )
 
     args = parser.parse_args()

--- a/openshift_metrics/tests/test_invoice.py
+++ b/openshift_metrics/tests/test_invoice.py
@@ -1,0 +1,69 @@
+from unittest import TestCase
+from datetime import datetime
+from decimal import Decimal
+
+from openshift_metrics import invoice
+
+
+class TestPodGetRuntime(TestCase):
+    def setUp(self):
+        """Gives us a pod that starts at 2024-10-11 12:00 UTC and ends at 2024-10-11 20:00 UTC"""
+        self.pod = invoice.Pod(
+            pod_name="test-pod",
+            namespace="test-namespace",
+            start_time=int(datetime(2024, 10, 11, 12, 0).timestamp()),
+            duration=3600 * 8,
+            cpu_request=Decimal("1.0"),
+            gpu_request=Decimal(0),
+            memory_request=Decimal("4.0"),
+            gpu_type=None,
+            gpu_resource=None,
+            node_hostname="node-1",
+            node_model=None,
+        )
+
+    def test_no_ignore_times(self):
+        runtime = self.pod.get_runtime()
+        self.assertEqual(runtime, Decimal("8.0"))
+
+    def test_one_ignore_range(self):
+        ignore_range = [(datetime(2024, 10, 11, 13, 0), datetime(2024, 10, 11, 14, 0))]
+        self.assertEqual(self.pod.get_runtime(ignore_range), Decimal(7.0))
+
+    def test_multiple_ignore_times(self):
+        ignore_times = [
+            (datetime(2024, 10, 11, 13, 0), datetime(2024, 10, 11, 14, 0)),
+            (datetime(2024, 10, 11, 14, 0), datetime(2024, 10, 11, 15, 0)),
+            (datetime(2024, 10, 11, 19, 0), datetime(2024, 10, 11, 20, 0)),
+        ]
+        self.assertEqual(self.pod.get_runtime(ignore_times), Decimal(5.0))
+
+    def test_ignore_times_outside_runtime(self):
+        ignore_times = [
+            (
+                datetime(2024, 10, 11, 10, 0),
+                datetime(2024, 10, 11, 11, 0),
+            ),  # before start
+            (datetime(2024, 10, 11, 20, 0), datetime(2024, 10, 11, 22, 0)),  # after end
+        ]
+        self.assertEqual(self.pod.get_runtime(ignore_times), Decimal(8.0))
+
+    def test_partial_overlap_ignore_range(self):
+        ignore_range = [
+            (datetime(2024, 10, 11, 10, 30), datetime(2024, 10, 11, 14, 30))
+        ]
+        self.assertEqual(self.pod.get_runtime(ignore_range), Decimal(5.5))
+
+    def test_ignore_range_greater_than_pod_runtime(self):
+        ignore_range = [
+            (datetime(2024, 10, 11, 11, 00), datetime(2024, 10, 11, 21, 00))
+        ]
+        self.assertEqual(self.pod.get_runtime(ignore_range), Decimal(0))
+
+    def test_runtime_is_never_negative(self):
+        ignore_times = [
+            (datetime(2024, 10, 11, 13, 0), datetime(2024, 10, 11, 17, 0)),
+            (datetime(2024, 10, 11, 13, 0), datetime(2024, 10, 11, 17, 0)),
+            (datetime(2024, 10, 11, 10, 0), datetime(2024, 10, 11, 22, 0)),
+        ]
+        self.assertEqual(self.pod.get_runtime(ignore_times), Decimal(0.0))

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -110,7 +110,7 @@ def csv_writer(rows, file_name):
         csvwriter.writerows(rows)
 
 
-def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month):
+def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, ignore_hours=None):
     """
     Process metrics dictionary to aggregate usage by namespace and then write that to a file
     """
@@ -157,7 +157,8 @@ def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month):
                 invoice_address="",
                 intitution="",
                 institution_specific_code=cf_institution_code,
-                rates=rates
+                rates=rates,
+                ignore_hours=ignore_hours,
             )
             invoices[namespace] = project_invoice
 
@@ -186,7 +187,7 @@ def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month):
     csv_writer(rows, file_name)
 
 
-def write_metrics_by_pod(condensed_metrics_dict, file_name):
+def write_metrics_by_pod(condensed_metrics_dict, file_name, ignore_hours=None):
     """
     Generates metrics report by pod.
     """
@@ -227,6 +228,6 @@ def write_metrics_by_pod(condensed_metrics_dict, file_name):
                     node_hostname=pod_metric_dict.get("node", "Unknown Node"),
                     node_model=pod_metric_dict.get("node_model", "Unknown Model"),
                 )
-                rows.append(pod_obj.generate_pod_row())
+                rows.append(pod_obj.generate_pod_row(ignore_hours))
 
     csv_writer(rows, file_name)


### PR DESCRIPTION
This adds a feature to allow us to ignore certain hours to not be billed. This works by ignoring those hours from being excluded from a pod's runtime.

Right now, the CLI can accept a bunch of timestamps to ignore but I think ultimately it'll come from the nerc-rates repo.

I ~am still working on writing a test~ have added tests for write_metrics_by_namespace with hours to ignore and a similar one for write_metrics_by_pod.
