### PR TITLE
This allows us to specify output directory in addition to the output …

### DIFF
--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -6,9 +6,14 @@ import argparse
 from datetime import datetime, UTC
 import json
 from typing import Tuple
+import os
+import logging
 
 from openshift_metrics import utils
 from openshift_metrics.metrics_processor import MetricsProcessor
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 def compare_dates(date_str1, date_str2):
     """Returns true is date1 is earlier than date2"""
@@ -35,7 +40,15 @@ def main():
     """Reads the metrics from files and generates the reports"""
     parser = argparse.ArgumentParser()
     parser.add_argument("files", nargs="+")
-    parser.add_argument("--output-file")
+    parser.add_argument(
+        "--output-file",
+        help = "Name of the invoice file. Defaults to NERC OpenShift <report_month>.csv"
+    )
+    parser.add_argument(
+        "--output-dir",
+        default = ".",
+        help = "Directory where the report files are generated (defaults to current directory)"
+    )
     parser.add_argument(
         "--upload-to-s3",
         action="store_true"
@@ -50,11 +63,10 @@ def main():
     args = parser.parse_args()
     files = args.files
 
-    if args.output_file:
-        output_file = args.output_file
-    else:
-        output_file = f"{datetime.today().strftime('%Y-%m-%d')}.csv"
     ignore_hours = args.ignore_hours
+
+    if not os.path.exists(args.output_dir):
+        os.makedirs(args.output_dir)
 
     report_start_date = None
     report_end_date = None
@@ -89,6 +101,17 @@ def main():
 
     report_month = datetime.strftime(report_start_date, "%Y-%m")
 
+    if args.output_file:
+        invoice_file = args.output_file
+    else:
+        invoice_file = f"NERC OpenShift {report_month}.csv"
+
+    pod_report_file = "Pod-" + invoice_file
+    invoice_path = os.path.join(args.output_dir, invoice_file)
+    pod_report_path = os.path.join(args.output_dir, pod_report_file)
+    logger.info("Invoice Path is: %s", invoice_path)
+    logger.info("Pod report path is: %s", pod_report_path)
+
     if report_start_date.month != report_end_date.month:
         print("Warning: The report spans multiple months")
         report_month += " to " + datetime.strftime(report_end_date, "%Y-%m")
@@ -98,30 +121,30 @@ def main():
     )
     utils.write_metrics_by_namespace(
         condensed_metrics_dict,
-        output_file,
+        invoice_path,
         report_month,
         ignore_hours,
     )
-    utils.write_metrics_by_pod(condensed_metrics_dict, "pod-" + output_file, ignore_hours)
+    utils.write_metrics_by_pod(condensed_metrics_dict, pod_report_path, ignore_hours)
 
     if args.upload_to_s3:
         primary_location = (
             f"Invoices/{report_month}/"
-            f"Service Invoices/NERC OpenShift {report_month}.csv"
+            f"Service Invoices/{invoice_file}"
         )
-        utils.upload_to_s3(output_file, "nerc-invoicing", primary_location)
+        utils.upload_to_s3(invoice_path, "nerc-invoicing", primary_location)
 
         timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
         secondary_location = (
             f"Invoices/{report_month}/"
             f"Archive/NERC OpenShift {report_month} {timestamp}.csv"
         )
-        utils.upload_to_s3(output_file, "nerc-invoicing", secondary_location)
+        utils.upload_to_s3(invoice_path, "nerc-invoicing", secondary_location)
         pod_report = (
             f"Invoices/{report_month}/"
             f"Archive/Pod-NERC OpenShift {report_month} {timestamp}.csv"
         )
-        utils.upload_to_s3("pod-" + output_file, "nerc-invoicing", pod_report)
+        utils.upload_to_s3(pod_report_path, "nerc-invoicing", pod_report)
 
 if __name__ == "__main__":
     main()

--- a/openshift_metrics/openshift_prometheus_metrics.py
+++ b/openshift_metrics/openshift_prometheus_metrics.py
@@ -55,6 +55,11 @@ def main():
         action="store_true"
     )
     parser.add_argument("--output-file")
+    parser.add_argument(
+        "--output-dir",
+        default = ".",
+        help = "Directory where the metrics file is stored (defaults to current directory)"
+    )
 
     args = parser.parse_args()
     if not args.openshift_url:
@@ -103,7 +108,8 @@ def main():
         pass
 
     month_year = datetime.strptime(report_start_date, "%Y-%m-%d").strftime("%Y-%m")
-    directory_name = f"data_{month_year}"
+    directory_name = args.output_dir
+    s3_location = f"data_{month_year}/{output_file}"
 
     if not os.path.exists(directory_name):
         os.makedirs(directory_name)
@@ -114,7 +120,7 @@ def main():
         json.dump(metrics_dict, file)
 
     if args.upload_to_s3:
-        utils.upload_to_s3(output_file, "openshift-metrics", output_file)
+        utils.upload_to_s3(output_file, "openshift-metrics", s3_location)
 
 
 if __name__ == "__main__":

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -17,10 +17,13 @@ import os
 import csv
 import requests
 import boto3
+import logging
 
 from openshift_metrics import invoice
 from decimal import Decimal
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 class EmptyResultError(Exception):
     """Raise when no results are retrieved for a query"""
@@ -69,7 +72,7 @@ def upload_to_s3(file, bucket, location):
         aws_access_key_id=s3_key_id,
         aws_secret_access_key=s3_secret,
     )
-
+    logger.info("Uploading file '%s' to 's3://%s/%s'", file, bucket, location)
     response = s3.upload_file(file, Bucket=bucket, Key=location)
 
 


### PR DESCRIPTION
…filename.

Previously, the output filename could include an absolute path, but this approach had limitations. When scripts run automatically, they require specific filenames for consistency, yet when run in a container we need the flexibility to specify different output directories. This change allows us to define the output directory independently from the output filename, making it easier to organize outputs without affecting automated filename requirements.

This also adds some basic logging to see where the files are being uploaded.