### PR TITLE
Accept absolute paths for filenames

### DIFF
--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -35,7 +35,14 @@ def main():
     """Reads the metrics from files and generates the reports"""
     parser = argparse.ArgumentParser()
     parser.add_argument("files", nargs="+")
-    parser.add_argument("--output-file")
+    parser.add_argument(
+        "--invoice-file",
+        help = "Name of the invoice file. Defaults to NERC OpenShift <report_month>.csv"
+    )
+    parser.add_argument(
+        "--pod-report-file",
+        help = "Name of the pod report file. Defaults to Pod NERC OpenShift <report_month>.csv"
+    )
     parser.add_argument(
         "--upload-to-s3",
         action="store_true"
@@ -49,11 +56,6 @@ def main():
 
     args = parser.parse_args()
     files = args.files
-
-    if args.output_file:
-        output_file = args.output_file
-    else:
-        output_file = f"{datetime.today().strftime('%Y-%m-%d')}.csv"
     ignore_hours = args.ignore_hours
 
     report_start_date = None
@@ -89,6 +91,16 @@ def main():
 
     report_month = datetime.strftime(report_start_date, "%Y-%m")
 
+    if args.invoice_file:
+        invoice_file = args.invoice_file
+    else:
+        invoice_file = f"NERC OpenShift {report_month}.csv"
+
+    if args.pod_report_file:
+        pod_report_file = args.pod_report_file
+    else:
+        pod_report_file = f"Pod NERC OpenShift {report_month}.csv"
+
     if report_start_date.month != report_end_date.month:
         print("Warning: The report spans multiple months")
         report_month += " to " + datetime.strftime(report_end_date, "%Y-%m")
@@ -98,30 +110,30 @@ def main():
     )
     utils.write_metrics_by_namespace(
         condensed_metrics_dict,
-        output_file,
+        invoice_file,
         report_month,
         ignore_hours,
     )
-    utils.write_metrics_by_pod(condensed_metrics_dict, "pod-" + output_file, ignore_hours)
+    utils.write_metrics_by_pod(condensed_metrics_dict, pod_report_file, ignore_hours)
 
     if args.upload_to_s3:
         primary_location = (
             f"Invoices/{report_month}/"
             f"Service Invoices/NERC OpenShift {report_month}.csv"
         )
-        utils.upload_to_s3(output_file, "nerc-invoicing", primary_location)
+        utils.upload_to_s3(invoice_file, "nerc-invoicing", primary_location)
 
         timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
         secondary_location = (
             f"Invoices/{report_month}/"
             f"Archive/NERC OpenShift {report_month} {timestamp}.csv"
         )
-        utils.upload_to_s3(output_file, "nerc-invoicing", secondary_location)
-        pod_report = (
+        utils.upload_to_s3(invoice_file, "nerc-invoicing", secondary_location)
+        pod_report_location = (
             f"Invoices/{report_month}/"
             f"Archive/Pod-NERC OpenShift {report_month} {timestamp}.csv"
         )
-        utils.upload_to_s3("pod-" + output_file, "nerc-invoicing", pod_report)
+        utils.upload_to_s3(pod_report_file, "nerc-invoicing", pod_report_location)
 
 if __name__ == "__main__":
     main()

--- a/openshift_metrics/openshift_prometheus_metrics.py
+++ b/openshift_metrics/openshift_prometheus_metrics.py
@@ -103,18 +103,17 @@ def main():
         pass
 
     month_year = datetime.strptime(report_start_date, "%Y-%m-%d").strftime("%Y-%m")
-    directory_name = f"data_{month_year}"
 
-    if not os.path.exists(directory_name):
-        os.makedirs(directory_name)
-
-    output_file = os.path.join(directory_name, output_file)
+    if report_start_date == report_end_date:
+        s3_location = f"data_{month_year}/metrics-{report_start_date}.json"
+    else:
+        s3_location = f"data_{month_year}/metrics-{report_start_date}-to-{report_end_date}.json"
 
     with open(output_file, "w") as file:
         json.dump(metrics_dict, file)
 
     if args.upload_to_s3:
-        utils.upload_to_s3(output_file, "openshift-metrics", output_file)
+        utils.upload_to_s3(output_file, "openshift-metrics", s3_location)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
For the merge.py, we now take in the names for the invoice file and the pod report file. The names of the S3 keys are calculated are not affected by this.

In the metrics collection script, the now output file name is also absolute. We no longer create any directory to organize the metrics in a folder. However when the names are uploaded to the S3 bucket, the key is organized and the names are calculated.

This allows us to generated the files in /tmp (or any other directory) with arbritary names but the file names uploaded to s3 are still calculated.