### PR TITLE
Use nerc-rates for billing

### DIFF
--- a/bin/produce_report.sh
+++ b/bin/produce_report.sh
@@ -3,4 +3,5 @@
 python -m openshift_metrics.merge /data/*.json \
     --invoice-file /tmp/invoice.csv \
     --pod-report-file /tmp/pod-report.csv \
-    --upload-to-s3
+    --upload-to-s3 \
+    --use-nerc-rates

--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -7,7 +7,7 @@ from datetime import datetime, UTC
 import json
 from typing import Tuple
 from decimal import Decimal
-from nerc_rates import load_from_url
+import nerc_rates
 
 from openshift_metrics import utils, invoice
 from openshift_metrics.metrics_processor import MetricsProcessor
@@ -103,12 +103,12 @@ def main():
     report_month = datetime.strftime(report_start_date, "%Y-%m")
 
     if args.use_nerc_rates:
-        nerc_rates = load_from_url()
+        nerc_data = nerc_rates.load_from_url()
         rates = invoice.Rates(
-            cpu=Decimal(nerc_rates.get_value_at("CPU SU Rate", report_month)),
-            gpu_a100=Decimal(nerc_rates.get_value_at("GPUA100 SU Rate", report_month)),
-            gpu_a100sxm4=Decimal(nerc_rates.get_value_at("GPUA100SXM4 SU Rate", report_month)),
-            gpu_v100=Decimal(nerc_rates.get_value_at("GPUV100 SU Rate", report_month)),
+            cpu=Decimal(nerc_data.get_value_at("CPU SU Rate", report_month)),
+            gpu_a100=Decimal(nerc_data.get_value_at("GPUA100 SU Rate", report_month)),
+            gpu_a100sxm4=Decimal(nerc_data.get_value_at("GPUA100SXM4 SU Rate", report_month)),
+            gpu_v100=Decimal(nerc_data.get_value_at("GPUV100 SU Rate", report_month)),
         )
     else:
         rates = invoice.Rates(

--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -6,8 +6,10 @@ import argparse
 from datetime import datetime, UTC
 import json
 from typing import Tuple
+from decimal import Decimal
+from nerc_rates import load_from_url
 
-from openshift_metrics import utils
+from openshift_metrics import utils, invoice
 from openshift_metrics.metrics_processor import MetricsProcessor
 
 def compare_dates(date_str1, date_str2):
@@ -53,6 +55,15 @@ def main():
         nargs="*",
         help="List of timestamp ranges in UTC to ignore in the format 'YYYY-MM-DDTHH:MM:SS,YYYY-MM-DDTHH:MM:SS'"
     )
+    parser.add_argument(
+        "--use-nerc-rates",
+        action="store_true",
+        help="Use rates from the nerc-rates repo",
+    )
+    parser.add_argument("--rate-cpu-su", type=Decimal)
+    parser.add_argument("--rate-gpu-v100-su", type=Decimal)
+    parser.add_argument("--rate-gpu-a100sxm4-su", type=Decimal)
+    parser.add_argument("--rate-gpu-a100-su", type=Decimal)
 
     args = parser.parse_args()
     files = args.files
@@ -91,6 +102,22 @@ def main():
 
     report_month = datetime.strftime(report_start_date, "%Y-%m")
 
+    if args.use_nerc_rates:
+        nerc_rates = load_from_url()
+        rates = invoice.Rates(
+            cpu=Decimal(nerc_rates.get_value_at("CPU SU Rate", report_month)),
+            gpu_a100=Decimal(nerc_rates.get_value_at("GPUA100 SU Rate", report_month)),
+            gpu_a100sxm4=Decimal(nerc_rates.get_value_at("GPUA100SXM4 SU Rate", report_month)),
+            gpu_v100=Decimal(nerc_rates.get_value_at("GPUV100 SU Rate", report_month)),
+        )
+    else:
+        rates = invoice.Rates(
+            cpu=Decimal(args.rate_cpu_su),
+            gpu_a100=Decimal(args.rate_gpu_a100_su),
+            gpu_a100sxm4=Decimal(args.rate_gpu_a100sxm4_su),
+            gpu_v100=Decimal(args.rate_gpu_v100_su)
+        )
+
     if args.invoice_file:
         invoice_file = args.invoice_file
     else:
@@ -109,10 +136,11 @@ def main():
         ["cpu_request", "memory_request", "gpu_request", "gpu_type"]
     )
     utils.write_metrics_by_namespace(
-        condensed_metrics_dict,
-        invoice_file,
-        report_month,
-        ignore_hours,
+        condensed_metrics_dict=condensed_metrics_dict,
+        file_name=invoice_file,
+        report_month=report_month,
+        rates=rates,
+        ignore_hours=ignore_hours,
     )
     utils.write_metrics_by_pod(condensed_metrics_dict, pod_report_file, ignore_hours)
 

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -110,7 +110,7 @@ def csv_writer(rows, file_name):
         csvwriter.writerows(rows)
 
 
-def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, ignore_hours=None):
+def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, rates, ignore_hours=None):
     """
     Process metrics dictionary to aggregate usage by namespace and then write that to a file
     """
@@ -133,14 +133,6 @@ def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, 
     ]
 
     rows.append(headers)
-
-    # TODO: the caller will pass in the rates as an argument
-    rates = invoice.Rates(
-        cpu = Decimal("0.013"),
-        gpu_a100 = Decimal("1.803"),
-        gpu_a100sxm4 = Decimal("2.078"),
-        gpu_v100 = Decimal("1.214")
-    )
 
     for namespace, pods in condensed_metrics_dict.items():
         namespace_annotation_dict = namespace_annotations.get(namespace, {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests>=2.18.4
 boto3>=1.34.40
-git+https://github.com/CCI-MOC/nerc-rates#egg=nerc_rates
+https://github.com/CCI-MOC/nerc-rates/archive/main.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.18.4
 boto3>=1.34.40
+git+https://github.com/CCI-MOC/nerc-rates#egg=nerc_rates


### PR DESCRIPTION
This add the necessary code to get rates from the nerc-rates repo or specify them from the command line. The "produce report" script is updated to use nerc-rates.

Addtionaly the tests were updated since the function `write_metrics_by_namespace` now takes an additional argument. All the calls to that function have been updated to keep things more readable.