### PR TITLE
Because openshift reserves some CPUs which makes allocateable CPUs fewer

### DIFF
--- a/openshift_metrics/invoice.py
+++ b/openshift_metrics/invoice.py
@@ -77,7 +77,7 @@ class Pod:
         su_config = {
             SU_CPU: {"gpu": -1, "cpu": 1, "ram": 4},
             SU_A100_GPU: {"gpu": 1, "cpu": 24, "ram": 74},
-            SU_A100_SXM4_GPU: {"gpu": 1, "cpu": 32, "ram": 240},
+            SU_A100_SXM4_GPU: {"gpu": 1, "cpu": 31, "ram": 240},
             SU_V100_GPU: {"gpu": 1, "cpu": 48, "ram": 192},
             SU_UNKNOWN_GPU: {"gpu": 1, "cpu": 8, "ram": 64},
             SU_UNKNOWN_MIG_GPU: {"gpu": 1, "cpu": 8, "ram": 64},

--- a/openshift_metrics/tests/test_utils.py
+++ b/openshift_metrics/tests/test_utils.py
@@ -451,7 +451,7 @@ class TestGetServiceUnit(TestCase):
         self.assertEqual(determining_resource, "GPU")
 
     def test_known_gpu_A100_SXM4(self):
-        pod = self.make_pod(32, 240, 1, invoice.GPU_A100_SXM4, invoice.WHOLE_GPU)
+        pod = self.make_pod(31, 240, 1, invoice.GPU_A100_SXM4, invoice.WHOLE_GPU)
         su_type, su_count, determining_resource = pod.get_service_unit()
         self.assertEqual(su_type, invoice.SU_A100_SXM4_GPU)
         self.assertEqual(su_count, 1)


### PR DESCRIPTION
thatn the total.

We should merge this after https://github.com/nerc-project/nerc-docs/pull/244/files is approved