### PR TITLE
Add query to get pod labels and generate report by class labels

### DIFF
--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -141,7 +141,6 @@ def main():
     condensed_metrics_dict = processor.condense_metrics(
         ["cpu_request", "memory_request", "gpu_request", "gpu_type"]
     )
-
     utils.write_metrics_by_namespace(
         condensed_metrics_dict=condensed_metrics_dict,
         file_name=invoice_file,

--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -141,11 +141,20 @@ def main():
     condensed_metrics_dict = processor.condense_metrics(
         ["cpu_request", "memory_request", "gpu_request", "gpu_type"]
     )
+
     utils.write_metrics_by_namespace(
         condensed_metrics_dict=condensed_metrics_dict,
         file_name=invoice_file,
         report_month=report_month,
         rates=rates,
+        ignore_hours=ignore_hours,
+    )
+    utils.write_metrics_by_classes(
+        condensed_metrics_dict=condensed_metrics_dict,
+        file_name=invoice_file,
+        report_month=report_month,
+        rates=rates,
+        namespaces_with_classes=["rhods-notebooks"],
         ignore_hours=ignore_hours,
     )
     utils.write_metrics_by_pod(condensed_metrics_dict, pod_report_file, ignore_hours)

--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -151,7 +151,7 @@ def main():
     )
     utils.write_metrics_by_classes(
         condensed_metrics_dict=condensed_metrics_dict,
-        file_name=invoice_file,
+        file_name=f"by-classes-{invoice_file}",
         report_month=report_month,
         rates=rates,
         namespaces_with_classes=["rhods-notebooks"],

--- a/openshift_metrics/metrics_processor.py
+++ b/openshift_metrics/metrics_processor.py
@@ -205,7 +205,7 @@ class MetricsProcessor:
         for pod_label in pod_labels:
             pod_name = pod_label["metric"]["pod"]
             class_name = pod_label["metric"].get("label_nerc_mghpcc_org_class")
-            pod_label_dict[pod_name] = {"pod": pod_name, "class": class_name}
+            pod_label_dict[pod_name] = {"class": class_name}
 
         for pod in resource_request_metrics:
             pod_name = pod["metric"]["pod"]

--- a/openshift_metrics/metrics_processor.py
+++ b/openshift_metrics/metrics_processor.py
@@ -25,7 +25,6 @@ class MetricsProcessor:
 
     def merge_metrics(self, metric_name, metric_list):
         """Merge metrics (cpu, memory, gpu) by pod"""
-
         for metric in metric_list:
             pod = metric["metric"]["pod"]
             namespace = metric["metric"]["namespace"]
@@ -33,6 +32,11 @@ class MetricsProcessor:
 
             self.merged_data.setdefault(namespace, {})
             self.merged_data[namespace].setdefault(pod, {"metrics": {}})
+
+            if metric_name == "cpu_request":
+                class_name = metric["metric"].get("label_nerc_mghpcc_org_class")
+                if class_name is not None:
+                    self.merged_data[namespace][pod]["label_nerc_mghpcc_org_class"] = class_name
 
             gpu_type, gpu_resource, node_model = self._extract_gpu_info(
                 metric_name, metric
@@ -191,5 +195,23 @@ class MetricsProcessor:
             )
             pod["metric"]["label_nvidia_com_gpu_machine"] = node_label_dict[node].get(
                 "machine"
+            )
+        return resource_request_metrics
+
+    @staticmethod
+    def insert_pod_labels(pod_labels: list, resource_request_metrics: list) -> list:
+        """Inserts `label_nerc_mghpcc_org_class` label into resource_request_metrics"""
+        pod_label_dict = {}
+        for pod_label in pod_labels:
+            pod_name = pod_label["metric"]["pod"]
+            class_name = pod_label["metric"].get("label_nerc_mghpcc_org_class")
+            pod_label_dict[pod_name] = {"pod": pod_name, "class": class_name}
+
+        for pod in resource_request_metrics:
+            pod_name = pod["metric"]["pod"]
+            if pod_name not in pod_label_dict:
+                continue
+            pod["metric"]["label_nerc_mghpcc_org_class"] = pod_label_dict[pod_name].get(
+                "class"
             )
         return resource_request_metrics

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -300,4 +300,4 @@ def write_metrics_by_classes(condensed_metrics_dict, file_name, report_month, ra
     for project_invoice in invoices.values():
         rows.extend(project_invoice.generate_invoice_rows(report_month))
 
-    csv_writer(rows, f"By-class-{file_name}")
+    csv_writer(rows, file_name)


### PR DESCRIPTION
This was a request so we can get a breakdown of the rhods-notebooks namespace by class. There's a mutating webhook that adds a label to the pod which is what we use to figure out which class a pod belongs to.

Note that this does not mess with the original invoice and instead generates a new report. 