### PR TITLE
Add option to set cluster_name when uploading report to S3/B2

### DIFF
--- a/k8s/base/produce-report-cronjob.yaml
+++ b/k8s/base/produce-report-cronjob.yaml
@@ -12,6 +12,8 @@ spec:
           - name: daily-openshift-metrics-collector
             image: ghcr.io/cci-moc/openshift-usage-scripts:main
             env:
+            - name: OPENSHIFT_CLUSTER_NAME
+              value: nerc-ocp-prod
             - name: S3_OUTPUT_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -160,21 +160,23 @@ def main():
 
     if args.upload_to_s3:
         bucket_name = os.environ.get("S3_INVOICE_BUCKET", "nerc-invoicing")
+        cluster_name = os.environ.get("OPENSHIFT_CLUSTER_NAME")
+        assert cluster_name, "Please set OPENSHIFT_CLUSTER_NAME to upload to S3"
         primary_location = (
             f"Invoices/{report_month}/"
-            f"Service Invoices/NERC OpenShift {report_month}.csv"
+            f"Service Invoices/{cluster_name} {report_month}.csv"
         )
         utils.upload_to_s3(invoice_file, bucket_name, primary_location)
 
         timestamp = datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')
         secondary_location = (
             f"Invoices/{report_month}/"
-            f"Archive/NERC OpenShift {report_month} {timestamp}.csv"
+            f"Archive/{cluster_name} {report_month} {timestamp}.csv"
         )
         utils.upload_to_s3(invoice_file, bucket_name, secondary_location)
         pod_report_location = (
             f"Invoices/{report_month}/"
-            f"Archive/Pod-NERC OpenShift {report_month} {timestamp}.csv"
+            f"Archive/Pod-{cluster_name} {report_month} {timestamp}.csv"
         )
         utils.upload_to_s3(pod_report_file, bucket_name, pod_report_location)
 


### PR DESCRIPTION
Now that we need to upload reports from multiple openshift clusters to s3 I decided to use cluster_name in the key/name. I am open to other ideas.

@knikolla If I were to produce a report daily or weekly, how do you think we should name these files? Do we only upload to the archives in that case? 