### PR TITLE
Get SU definition from nerc-rates

### DIFF
--- a/openshift_metrics/invoice.py
+++ b/openshift_metrics/invoice.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 from typing import List, Tuple, Optional
 from decimal import Decimal, ROUND_HALF_UP
 import datetime
-import nerc_rates
 
 # GPU types
 GPU_A100 = "NVIDIA-A100-40GB"

--- a/openshift_metrics/tests/test_utils.py
+++ b/openshift_metrics/tests/test_utils.py
@@ -27,7 +27,7 @@ RATES = invoice.Rates(
     gpu_h100 = Decimal("6.04"),
     )
 
-SU_DEFINITIONS = merge.get_su_definitions("2025-03")
+SU_DEFINITIONS = merge.get_su_definitions("2025-04")
 
 class TestGetNamespaceAnnotations(TestCase):
 

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -114,7 +114,7 @@ def csv_writer(rows, file_name):
         csvwriter.writerows(rows)
 
 
-def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, rates, ignore_hours=None):
+def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, rates, su_definitions, ignore_hours=None):
     """
     Process metrics dictionary to aggregate usage by namespace and then write that to a file
     """
@@ -154,6 +154,7 @@ def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, 
                 intitution="",
                 institution_specific_code=cf_institution_code,
                 rates=rates,
+                su_definitions=su_definitions,
                 ignore_hours=ignore_hours,
             )
             invoices[namespace] = project_invoice
@@ -183,7 +184,7 @@ def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, 
     csv_writer(rows, file_name)
 
 
-def write_metrics_by_pod(condensed_metrics_dict, file_name, ignore_hours=None):
+def write_metrics_by_pod(condensed_metrics_dict, file_name, su_definitions, ignore_hours=None):
     """
     Generates metrics report by pod.
     """
@@ -224,11 +225,11 @@ def write_metrics_by_pod(condensed_metrics_dict, file_name, ignore_hours=None):
                     node_hostname=pod_metric_dict.get("node", "Unknown Node"),
                     node_model=pod_metric_dict.get("node_model", "Unknown Model"),
                 )
-                rows.append(pod_obj.generate_pod_row(ignore_hours))
+                rows.append(pod_obj.generate_pod_row(ignore_hours, su_definitions))
 
     csv_writer(rows, file_name)
 
-def write_metrics_by_classes(condensed_metrics_dict, file_name, report_month, rates, namespaces_with_classes, ignore_hours=None):
+def write_metrics_by_classes(condensed_metrics_dict, file_name, report_month, rates, namespaces_with_classes, su_definitions, ignore_hours=None):
     """
     Process metrics dictionary to aggregate usage by the class label.
 
@@ -275,6 +276,7 @@ def write_metrics_by_classes(condensed_metrics_dict, file_name, report_month, ra
                     invoice_address="",
                     intitution="",
                     institution_specific_code="",
+                    su_definitions=su_definitions,
                     rates=rates,
                     ignore_hours=ignore_hours,
                 )


### PR DESCRIPTION
This updates the get_service_unit method to get the SU definitions from
nerc-rates.

The second commit refactors things a bit to control how this information flows.

Closes https://github.com/CCI-MOC/openshift-usage-scripts/issues/112