### PR TITLE
Added `Cluster Name` column to invoice

### DIFF
--- a/k8s/base/produce-report-cronjob.yaml
+++ b/k8s/base/produce-report-cronjob.yaml
@@ -12,8 +12,6 @@ spec:
           - name: daily-openshift-metrics-collector
             image: ghcr.io/cci-moc/openshift-usage-scripts:main
             env:
-            - name: OPENSHIFT_CLUSTER_NAME
-              value: nerc-ocp-prod
             - name: S3_OUTPUT_ACCESS_KEY_ID
               valueFrom:
                 secretKeyRef:

--- a/openshift_metrics/invoice.py
+++ b/openshift_metrics/invoice.py
@@ -196,6 +196,7 @@ class ProjectInvoce:
     project: str
     project_id: str
     pi: str
+    cluster_name: str
     invoice_email: str
     invoice_address: str
     intitution: str
@@ -247,6 +248,7 @@ class ProjectInvoce:
                     self.project,
                     self.project_id,
                     self.pi,
+                    self.cluster_name,
                     self.invoice_email,
                     self.invoice_address,
                     self.intitution,

--- a/openshift_metrics/merge.py
+++ b/openshift_metrics/merge.py
@@ -104,6 +104,7 @@ def main():
     for file in files:
         with open(file, "r") as jsonfile:
             metrics_from_file = json.load(jsonfile)
+            cluster_name = metrics_from_file["cluster_name"]
             cpu_request_metrics = metrics_from_file["cpu_metrics"]
             memory_request_metrics = metrics_from_file["memory_metrics"]
             gpu_request_metrics = metrics_from_file.get("gpu_metrics", None)
@@ -181,6 +182,7 @@ def main():
         report_month=report_month,
         rates=rates,
         su_definitions=su_definitions,
+        cluster_name=cluster_name,
         ignore_hours=ignore_hours,
     )
     utils.write_metrics_by_classes(
@@ -189,6 +191,7 @@ def main():
         report_month=report_month,
         rates=rates,
         su_definitions=su_definitions,
+        cluster_name=cluster_name,
         namespaces_with_classes=["rhods-notebooks"],
         ignore_hours=ignore_hours,
     )
@@ -201,8 +204,6 @@ def main():
 
     if args.upload_to_s3:
         bucket_name = os.environ.get("S3_INVOICE_BUCKET", "nerc-invoicing")
-        cluster_name = os.environ.get("OPENSHIFT_CLUSTER_NAME")
-        assert cluster_name, "Please set OPENSHIFT_CLUSTER_NAME to upload to S3"
         primary_location = (
             f"Invoices/{report_month}/"
             f"Service Invoices/{cluster_name} {report_month}.csv"

--- a/openshift_metrics/openshift_prometheus_metrics.py
+++ b/openshift_metrics/openshift_prometheus_metrics.py
@@ -33,6 +33,11 @@ GPU_REQUEST = 'kube_pod_resource_request{resource=~"nvidia.com.*", node!=""} unl
 KUBE_NODE_LABELS = 'kube_node_labels{label_nvidia_com_gpu_product!=""}'
 KUBE_POD_LABELS = 'kube_pod_labels{label_nerc_mghpcc_org_class!=""}'
 
+URL_CLUSTER_NAME_MAPPING = {
+    "https://thanos-querier-openshift-monitoring.apps.shift.nerc.mghpcc.org": "ocp-prod",
+    "https://thanos-querier-openshift-monitoring.apps.ocp-test.nerc.mghpcc.org": "ocp-test",
+}
+
 def main():
     """This method kick starts the process of collecting and saving the metrics"""
 
@@ -84,6 +89,7 @@ def main():
     metrics_dict = {}
     metrics_dict["start_date"] = report_start_date
     metrics_dict["end_date"] = report_end_date
+    metrics_dict["cluster_name"] = URL_CLUSTER_NAME_MAPPING.get(args.openshift_url, args.openshift_url)
 
     cpu_request_metrics = prom_client.query_metric(
         CPU_REQUEST, report_start_date, report_end_date

--- a/openshift_metrics/tests/test_utils.py
+++ b/openshift_metrics/tests/test_utils.py
@@ -181,11 +181,11 @@ class TestWriteMetricsByNamespace(TestCase):
             }
         }
 
-        expected_output = ("Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
-                            "2023-01,namespace1,namespace1,,,,,,1128,OpenShift CPU,0.013,14.66\n"
-                            "2023-01,namespace2,namespace2,,,,,,96,OpenShift CPU,0.013,1.25\n"
-                            "2023-01,namespace2,namespace2,,,,,,48,OpenShift GPUA100,1.803,86.54\n"
-                            "2023-01,namespace2,namespace2,,,,,,48,OpenShift GPUA100SXM4,2.078,99.74\n")
+        expected_output = ("Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Cluster Name,Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
+                            "2023-01,namespace1,namespace1,,test-cluster,,,,,1128,OpenShift CPU,0.013,14.66\n"
+                            "2023-01,namespace2,namespace2,,test-cluster,,,,,96,OpenShift CPU,0.013,1.25\n"
+                            "2023-01,namespace2,namespace2,,test-cluster,,,,,48,OpenShift GPUA100,1.803,86.54\n"
+                            "2023-01,namespace2,namespace2,,test-cluster,,,,,48,OpenShift GPUA100SXM4,2.078,99.74\n")
 
         with tempfile.NamedTemporaryFile(mode="w+") as tmp:
             utils.write_metrics_by_namespace(
@@ -194,6 +194,7 @@ class TestWriteMetricsByNamespace(TestCase):
                 report_month="2023-01",
                 rates=RATES,
                 su_definitions=SU_DEFINITIONS,
+                cluster_name="test-cluster",
                 )
             self.assertEqual(tmp.read(), expected_output)
 
@@ -227,9 +228,9 @@ class TestWriteMetricsByNamespace(TestCase):
             },
         }
 
-        expected_output = ("Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
-                            "2023-01,namespace1,namespace1,,,,,,24,OpenShift GPUA100SXM4,2.078,49.87\n"
-                            "2023-01,namespace1,namespace1,,,,,,24,OpenShift GPUH100,6.04,144.96\n")
+        expected_output = ("Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Cluster Name,Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
+                            "2023-01,namespace1,namespace1,,test-cluster,,,,,24,OpenShift GPUA100SXM4,2.078,49.87\n"
+                            "2023-01,namespace1,namespace1,,test-cluster,,,,,24,OpenShift GPUH100,6.04,144.96\n")
 
         with tempfile.NamedTemporaryFile(mode="w+") as tmp:
             utils.write_metrics_by_namespace(
@@ -238,6 +239,7 @@ class TestWriteMetricsByNamespace(TestCase):
                 report_month="2023-01",
                 rates=RATES,
                 su_definitions=SU_DEFINITIONS,
+                cluster_name="test-cluster",
                 )
             self.assertEqual(tmp.read(), expected_output)
 
@@ -316,11 +318,11 @@ class TestWriteMetricsByClasses(TestCase):
             }
         }
 
-        expected_output = ("Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
-                            "2023-01,namespace2:noclass,namespace2:noclass,,,,,,96,OpenShift CPU,0.013,1.25\n"
-                            "2023-01,namespace2:math-201,namespace2:math-201,,,,,,96,OpenShift CPU,0.013,1.25\n"
-                            "2023-01,namespace2:math-201,namespace2:math-201,,,,,,24,OpenShift GPUA100,1.803,43.27\n"
-                            "2023-01,namespace2:cs-101,namespace2:cs-101,,,,,,48,OpenShift GPUA100SXM4,2.078,99.74\n")
+        expected_output = ("Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Cluster Name,Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
+                            "2023-01,namespace2:noclass,namespace2:noclass,,test-cluster,,,,,96,OpenShift CPU,0.013,1.25\n"
+                            "2023-01,namespace2:math-201,namespace2:math-201,,test-cluster,,,,,96,OpenShift CPU,0.013,1.25\n"
+                            "2023-01,namespace2:math-201,namespace2:math-201,,test-cluster,,,,,24,OpenShift GPUA100,1.803,43.27\n"
+                            "2023-01,namespace2:cs-101,namespace2:cs-101,,test-cluster,,,,,48,OpenShift GPUA100SXM4,2.078,99.74\n")
 
         with tempfile.NamedTemporaryFile(mode="w+") as tmp:
             utils.write_metrics_by_classes(
@@ -329,7 +331,8 @@ class TestWriteMetricsByClasses(TestCase):
                 report_month="2023-01",
                 rates=RATES,
                 su_definitions=SU_DEFINITIONS,
-                namespaces_with_classes=["namespace2"]
+                namespaces_with_classes=["namespace2"],
+                cluster_name="test-cluster",
                 )
             self.assertEqual(tmp.read(), expected_output)
 
@@ -362,8 +365,8 @@ class TestWriteMetricsByClasses(TestCase):
         cost = round(duration*rate,2)
         self.assertEqual(cost, 0.45)
 
-        expected_output = ("Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
-                            "2023-01,namespace1,namespace1,,,,,,35,OpenShift CPU,0.013,0.46\n")
+        expected_output = ("Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Cluster Name,Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
+                            "2023-01,namespace1,namespace1,,test-cluster,,,,,35,OpenShift CPU,0.013,0.46\n")
 
         with tempfile.NamedTemporaryFile(mode="w+") as tmp:
             utils.write_metrics_by_namespace(
@@ -371,7 +374,8 @@ class TestWriteMetricsByClasses(TestCase):
                 file_name=tmp.name,
                 report_month="2023-01",
                 su_definitions=SU_DEFINITIONS,
-                rates=RATES
+                rates=RATES,
+                cluster_name="test-cluster",
                 )
             self.assertEqual(tmp.read(), expected_output)
 
@@ -439,10 +443,10 @@ class TestWriteMetricsWithIgnoreHours(TestCase):
 
     def test_write_metrics_by_namespace_with_ignore_hours(self):
         expected_output = (
-            "Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
-            "2023-01,namespace1,namespace1,,,,,,12,OpenShift CPU,0.013,0.16\n"
-            "2023-01,namespace2,namespace2,,,,,,170,OpenShift CPU,0.013,2.21\n"
-            "2023-01,namespace2,namespace2,,,,,,37,OpenShift GPUA100SXM4,2.078,76.89\n"
+            "Invoice Month,Project - Allocation,Project - Allocation ID,Manager (PI),Cluster Name,Invoice Email,Invoice Address,Institution,Institution - Specific Code,SU Hours (GBhr or SUhr),SU Type,Rate,Cost\n"
+            "2023-01,namespace1,namespace1,,test-cluster,,,,,12,OpenShift CPU,0.013,0.16\n"
+            "2023-01,namespace2,namespace2,,test-cluster,,,,,170,OpenShift CPU,0.013,2.21\n"
+            "2023-01,namespace2,namespace2,,test-cluster,,,,,37,OpenShift GPUA100SXM4,2.078,76.89\n"
         )
 
         with tempfile.NamedTemporaryFile(mode="w+") as tmp:
@@ -452,6 +456,7 @@ class TestWriteMetricsWithIgnoreHours(TestCase):
                 report_month="2023-01",
                 rates=RATES,
                 su_definitions=SU_DEFINITIONS,
+                cluster_name="test-cluster",
                 ignore_hours=self.ignore_times
             )
             self.assertEqual(tmp.read(), expected_output)

--- a/openshift_metrics/utils.py
+++ b/openshift_metrics/utils.py
@@ -56,7 +56,7 @@ def csv_writer(rows, file_name):
         csvwriter.writerows(rows)
 
 
-def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, rates, su_definitions, ignore_hours=None):
+def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, rates, su_definitions, cluster_name, ignore_hours=None):
     """
     Process metrics dictionary to aggregate usage by namespace and then write that to a file
     """
@@ -67,6 +67,7 @@ def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, 
         "Project - Allocation",
         "Project - Allocation ID",
         "Manager (PI)",
+        "Cluster Name",
         "Invoice Email",
         "Invoice Address",
         "Institution",
@@ -87,6 +88,7 @@ def write_metrics_by_namespace(condensed_metrics_dict, file_name, report_month, 
                 project=namespace,
                 project_id=namespace,
                 pi="",
+                cluster_name=cluster_name,
                 invoice_email="",
                 invoice_address="",
                 intitution="",
@@ -167,7 +169,7 @@ def write_metrics_by_pod(condensed_metrics_dict, file_name, su_definitions, igno
 
     csv_writer(rows, file_name)
 
-def write_metrics_by_classes(condensed_metrics_dict, file_name, report_month, rates, namespaces_with_classes, su_definitions, ignore_hours=None):
+def write_metrics_by_classes(condensed_metrics_dict, file_name, report_month, rates, namespaces_with_classes, su_definitions, cluster_name, ignore_hours=None):
     """
     Process metrics dictionary to aggregate usage by the class label.
 
@@ -181,6 +183,7 @@ def write_metrics_by_classes(condensed_metrics_dict, file_name, report_month, ra
         "Project - Allocation",
         "Project - Allocation ID",
         "Manager (PI)",
+        "Cluster Name",
         "Invoice Email",
         "Invoice Address",
         "Institution",
@@ -210,6 +213,7 @@ def write_metrics_by_classes(condensed_metrics_dict, file_name, report_month, ra
                     project=project_name,
                     project_id=project_name,
                     pi="",
+                    cluster_name=cluster_name,
                     invoice_email="",
                     invoice_address="",
                     intitution="",


### PR DESCRIPTION
Closes #127. More details in the commit. 

@naved001 I decided to use `ocp-test` and `ocp-prod` since the `invoicing` repo already has [logic](https://github.com/CCI-MOC/invoicing/blob/0a8b8623072b0cb55022b5ed1053fa002eb124f0/process_report/processors/validate_billable_pi_processor.py#L13) for `ocp-test`, and it's [what we agreed upon before](https://github.com/CCI-MOC/invoicing/issues/165#issue-2944178437).