### PR TITLE
Make setting prometheus query interval minute configurable

### DIFF
--- a/openshift_metrics/config.py
+++ b/openshift_metrics/config.py
@@ -14,3 +14,5 @@ S3_ACCESS_KEY_ID = os.getenv("S3_OUTPUT_ACCESS_KEY_ID")
 S3_SECRET_ACCESS_KEY = os.getenv("S3_OUTPUT_SECRET_ACCESS_KEY")
 S3_INVOICE_BUCKET = os.getenv("S3_INVOICE_BUCKET", "nerc-invoicing")
 S3_METRICS_BUCKET = os.getenv("S3_METRICS_BUCKET", "openshift_metrics")
+PROM_QUERY_INTERVAL_MINUTES = int(os.getenv("PROM_QUERY_INTERVAL_MINUTES", 15))
+assert PROM_QUERY_INTERVAL_MINUTES >= 1, "Query interval must be at least 1 minute"

--- a/openshift_metrics/openshift_prometheus_metrics.py
+++ b/openshift_metrics/openshift_prometheus_metrics.py
@@ -26,6 +26,7 @@ from openshift_metrics.config import (
     OPENSHIFT_PROMETHEUS_URL,
     OPENSHIFT_TOKEN,
     S3_METRICS_BUCKET,
+    PROM_QUERY_INTERVAL_MINUTES,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -89,14 +90,17 @@ def main():
         output_file = f"metrics-{report_start_date}-to-{report_end_date}.json"
 
     logger.info(
-        f"Generating report starting {report_start_date} and ending {report_end_date} in {output_file}"
+        f"Generating report starting {report_start_date} and ending {report_end_date} in {output_file} with interval {PROM_QUERY_INTERVAL_MINUTES} minute"
     )
 
-    prom_client = PrometheusClient(openshift_url, OPENSHIFT_TOKEN)
+    prom_client = PrometheusClient(
+        openshift_url, OPENSHIFT_TOKEN, PROM_QUERY_INTERVAL_MINUTES
+    )
 
     metrics_dict = {}
     metrics_dict["start_date"] = report_start_date
     metrics_dict["end_date"] = report_end_date
+    metrics_dict["interval_minutes"] = PROM_QUERY_INTERVAL_MINUTES
     metrics_dict["cluster_name"] = URL_CLUSTER_NAME_MAPPING.get(
         args.openshift_url, args.openshift_url
     )


### PR DESCRIPTION
We have some clusters where we would like to change the frequency at which we collect metrics and generate the report based on that.

To accomplish this, we need to make 2 changes. We set an environment variable that is passed on to the metrics collector scripts. And we insert the collection interval into the json file.

The merge scripts will read this interval when loading these files. For backwards compatibility with our old metrics file, we'll default to 15 minutes when processing these files.

P.S. merge.py is getting a bit ugly so I am going to submit another PR that refactors some of the stuff and adds tests.