### PR TITLE
Add barcelona cluster name

### DIFF
--- a/openshift_metrics/openshift_prometheus_metrics.py
+++ b/openshift_metrics/openshift_prometheus_metrics.py
@@ -42,6 +42,7 @@ URL_CLUSTER_NAME_MAPPING = {
     "https://thanos-querier-openshift-monitoring.apps.shift.nerc.mghpcc.org": "ocp-prod",
     "https://thanos-querier-openshift-monitoring.apps.ocp-test.nerc.mghpcc.org": "ocp-test",
     "https://thanos-querier-openshift-monitoring.apps.edu.nerc.mghpcc.org": "academic",
+    "https://thanos-querier-openshift-monitoring.apps.barcelona.nerc.mghpcc.org": "barcelona",
 }
 
 


### PR DESCRIPTION
This should really just come from a config file instead of being hardcoded, so we can just update the config file when we need to add new clusters. But that's going to be a separate issue.